### PR TITLE
Fix MoonBit warnings for 2026-05-09 promotion

### DIFF
--- a/lexer/lexer.mbt
+++ b/lexer/lexer.mbt
@@ -1,5 +1,5 @@
 ///|
-let use_utf16_location : Ref[Bool] = Ref::new(false)
+let use_utf16_location : Ref[Bool] = Ref(false)
 
 ///|
 fn lex_tokens(

--- a/pkg_parser/parser.mbt
+++ b/pkg_parser/parser.mbt
@@ -346,7 +346,7 @@ fn parse_apply(state : State) -> (String, Ast) {
     state.report_expected_here("\"(\"")
     state.skip_until_statement_end()
     let loc = Location::{ start: args_start, end: args_start }
-    return (name, Obj(map=Map::new(), loc~))
+    return (name, Obj(map=Map([]), loc~))
   }
   let args = parse_comma_separated(state, right=TK_RPAREN, parse_argument)
   (name, Obj(map=Map::from_array(args), loc=state.loc_start_with(args_start)))
@@ -612,7 +612,7 @@ fn parse_statements(state : State) -> Array[(String, Ast)] {
 pub fn moon_pkg_of_tokens(tokens : Triples) -> (Ast, Array[Report]) {
   if tokens.is_empty() {
     let loc = Location::{ start: dummy_pos, end: dummy_pos }
-    return (Obj(map=Map::new(), loc~), [])
+    return (Obj(map=Map([]), loc~), [])
   }
   let start = tokens[0].1
   let state = State::{

--- a/pkg_parser/pkg_parser_test.mbt
+++ b/pkg_parser/pkg_parser_test.mbt
@@ -14,7 +14,7 @@ fn ast_summary(ast : Ast) -> Json {
       Json::object(Map::from_array([("$number", Json::string(float))]))
     Arr(content~, ..) => Json::array(content.map(ast_summary))
     Obj(map~, ..) => {
-      let object : Map[String, Json] = Map::new()
+      let object : Map[String, Json] = Map([])
       for key, value in map {
         object[key] = ast_summary(value)
       }

--- a/syntax/utils.mbt
+++ b/syntax/utils.mbt
@@ -3,7 +3,7 @@
 // Translated from src/ast/parsing_util.ml
 
 // Global counter for generating unique variable names
-let counter : Ref[Int] = Ref::new(0)
+let counter : Ref[Int] = Ref(0)
 
 ///|
 /// Create constant expression with location


### PR DESCRIPTION
## Summary
- Fix MoonBit warnings reported by the community-cakes dashboard for the 2026-05-09 promotion run.
- Update deprecated APIs as needed.

## Validation
- `moon check --target all`
- `moon test pkg_parser`
