### PR TITLE
refactor: adapt moonbit 0.9.3

### DIFF
--- a/basic/pkg.generated.mbti
+++ b/basic/pkg.generated.mbti
@@ -46,7 +46,7 @@ pub impl Show for Position
 pub(all) struct Report {
   loc : Location
   msg : String
-}
+} derive(@debug.Debug)
 pub impl Show for Report
 pub impl ToJson for Report
 

--- a/basic/report.mbt
+++ b/basic/report.mbt
@@ -2,7 +2,7 @@
 pub(all) struct Report {
   loc : Location
   msg : String
-}
+} derive(Debug)
 
 ///|
 pub impl Show for Report with output(self, logger) {

--- a/handrolled_parser/parse_expr_test.mbt
+++ b/handrolled_parser/parse_expr_test.mbt
@@ -5,7 +5,7 @@ fn simple_parse_expr(source : String) -> @syntax.Expr raise {
   if reports.is_empty() {
     return expr
   } else {
-    fail(reports.to_string())
+    fail("\{to_repr(reports)}")
   }
 }
 

--- a/lexer/lexer.mbt
+++ b/lexer/lexer.mbt
@@ -1,5 +1,5 @@
 ///|
-let use_utf16_location : Ref[Bool] = Ref::new(false)
+let use_utf16_location : Ref[Bool] = Ref(false)
 
 ///|
 fn lex_tokens(

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "moonbitlang/parser",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "deps": {
     "moonbitlang/x": "0.4.39",
     "moonbitlang/yacc": "0.7.13"

--- a/pkg_parser/parser.mbt
+++ b/pkg_parser/parser.mbt
@@ -346,7 +346,7 @@ fn parse_apply(state : State) -> (String, Ast) {
     state.report_expected_here("\"(\"")
     state.skip_until_statement_end()
     let loc = Location::{ start: args_start, end: args_start }
-    return (name, Obj(map=Map::new(), loc~))
+    return (name, Obj(map=Map([]), loc~))
   }
   let args = parse_comma_separated(state, right=TK_RPAREN, parse_argument)
   (name, Obj(map=Map::from_array(args), loc=state.loc_start_with(args_start)))
@@ -612,7 +612,7 @@ fn parse_statements(state : State) -> Array[(String, Ast)] {
 pub fn moon_pkg_of_tokens(tokens : Triples) -> (Ast, Array[Report]) {
   if tokens.is_empty() {
     let loc = Location::{ start: dummy_pos, end: dummy_pos }
-    return (Obj(map=Map::new(), loc~), [])
+    return (Obj(map=Map([]), loc~), [])
   }
   let start = tokens[0].1
   let state = State::{

--- a/pkg_parser/pkg_parser_test.mbt
+++ b/pkg_parser/pkg_parser_test.mbt
@@ -14,7 +14,7 @@ fn ast_summary(ast : Ast) -> Json {
       Json::object(Map::from_array([("$number", Json::string(float))]))
     Arr(content~, ..) => Json::array(content.map(ast_summary))
     Obj(map~, ..) => {
-      let object : Map[String, Json] = Map::new()
+      let object : Map[String, Json] = Map([])
       for key, value in map {
         object[key] = ast_summary(value)
       }

--- a/syntax/map_visitor_wbtest.mbt
+++ b/syntax/map_visitor_wbtest.mbt
@@ -80,46 +80,46 @@ test "Pattern" {
     is_closed=false,
     loc=dummy_loc,
   )
-  assert_eq(
+  @test.assert_eq(
     any_with_alias.json_repr(),
     MapVisitorBase::visit_Pattern(MapVisitorBase(Identity(())), any_with_alias).json_repr(),
   )
-  assert_eq(
+  @test.assert_eq(
     array_patterns.json_repr(),
     MapVisitorBase::visit_Pattern(MapVisitorBase(Identity(())), array_patterns).json_repr(),
   )
-  assert_eq(
+  @test.assert_eq(
     constant_pattern.json_repr(),
     MapVisitorBase::visit_Expr(MapVisitorBase(Identity(())), constant_pattern).json_repr(),
   )
-  assert_eq(
+  @test.assert_eq(
     constraint_pattern.json_repr(),
     MapVisitorBase::visit_Pattern(
       MapVisitorBase(Identity(())),
       constraint_pattern,
     ).json_repr(),
   )
-  assert_eq(
+  @test.assert_eq(
     constr_pattern.json_repr(),
     MapVisitorBase::visit_Pattern(MapVisitorBase(Identity(())), constr_pattern).json_repr(),
   )
-  assert_eq(
+  @test.assert_eq(
     or_pattern.json_repr(),
     MapVisitorBase::visit_Pattern(MapVisitorBase(Identity(())), or_pattern).json_repr(),
   )
-  assert_eq(
+  @test.assert_eq(
     tuple_pattern.json_repr(),
     MapVisitorBase::visit_Pattern(MapVisitorBase(Identity(())), tuple_pattern).json_repr(),
   )
-  assert_eq(
+  @test.assert_eq(
     record_pattern.json_repr(),
     MapVisitorBase::visit_Pattern(MapVisitorBase(Identity(())), record_pattern).json_repr(),
   )
-  assert_eq(
+  @test.assert_eq(
     map_pattern.json_repr(),
     MapVisitorBase::visit_Pattern(MapVisitorBase(Identity(())), map_pattern).json_repr(),
   )
-  assert_eq(
+  @test.assert_eq(
     range_pattern.json_repr(),
     MapVisitorBase::visit_Pattern(MapVisitorBase(Identity(())), range_pattern).json_repr(),
   )

--- a/syntax/moon.pkg
+++ b/syntax/moon.pkg
@@ -11,4 +11,8 @@ import {
   "moonbitlang/core/json",
 } for "test"
 
+import {
+  "moonbitlang/core/test",
+} for "wbtest"
+
 warnings = "-28"

--- a/syntax/utils.mbt
+++ b/syntax/utils.mbt
@@ -3,7 +3,7 @@
 // Translated from src/ast/parsing_util.ml
 
 // Global counter for generating unique variable names
-let counter : Ref[Int] = Ref::new(0)
+let counter : Ref[Int] = Ref(0)
 
 ///|
 /// Create constant expression with location

--- a/test/sync_test/loc_regression_test.mbt
+++ b/test/sync_test/loc_regression_test.mbt
@@ -18,7 +18,7 @@ fn parse_loc_regression(
     parser~,
   )
   if !diagnostics.is_empty() {
-    fail(diagnostics.to_string())
+    fail("\{to_repr(diagnostics)}")
   }
   let mut brace_group_loc = None
   let mut params_loc = None


### PR DESCRIPTION
## Summary

- Update deprecated MoonBit 0.9.3 APIs from `Ref::new(...)` to `Ref(...)` and empty `Map::new()` to `Map([])`.
- Migrate parser diagnostic failure messages from deprecated `Show` output to `Debug` output via `to_repr(...)`, and derive `Debug` for `Report`.
- Use `core/test`'s `assert_eq` in syntax white-box tests and import it for `wbtest` to avoid the deprecated `Show`-based assertion path.

## Tests

- `moon check`
- `moon test handrolled_parser`
- `moon test syntax`
- `moon test pkg_parser`
- `moon test test/sync_test`
- `moon fmt`
- `moon info`