### PR TITLE
use string interpolation instead of concatenation

### DIFF
--- a/handrolled_parser/parser.mbt
+++ b/handrolled_parser/parser.mbt
@@ -1783,17 +1783,17 @@ fn State::parse_simple_pattern(self : Self) -> @syntax.Pattern {
         INT(x) => {
           let loc = self.peek_location()
           self.expect_token(TK_INT)
-          Constant(c=@syntax.make_int("-" + x), loc~)
+          Constant(c=@syntax.make_int("-\{x}"), loc~)
         }
         FLOAT(x) => {
           let loc = self.peek_location()
           self.expect_token(TK_FLOAT)
-          Constant(c=@syntax.make_float("-" + x), loc~)
+          Constant(c=@syntax.make_float("-\{x}"), loc~)
         }
         DOUBLE(x) => {
           let loc = self.peek_location()
           self.expect_token(TK_DOUBLE)
-          Constant(c=@syntax.make_double("-" + x), loc~)
+          Constant(c=@syntax.make_double("-\{x}"), loc~)
         }
         other => {
           let other_loc = self.peek_location()
@@ -2006,9 +2006,9 @@ fn State::parse_simple_pattern(self : Self) -> @syntax.Pattern {
             MINUS => {
               self.expect_token(TK_MINUS)
               match self.peek_token() {
-                INT(x) => parse_map_elem_pat(@syntax.make_int("-" + x))
-                FLOAT(x) => parse_map_elem_pat(@syntax.make_float("-" + x))
-                DOUBLE(x) => parse_map_elem_pat(Double("-" + x))
+                INT(x) => parse_map_elem_pat(@syntax.make_int("-\{x}"))
+                FLOAT(x) => parse_map_elem_pat(@syntax.make_float("-\{x}"))
+                DOUBLE(x) => parse_map_elem_pat(Double("-\{x}"))
                 other => {
                   let other_loc = self.peek_location()
                   self.report_failed_to_parse(
@@ -4868,9 +4868,9 @@ fn State::parse_map_expr(self : Self) -> @syntax.Expr {
       MINUS => {
         state.skip()
         match state.peek_token() {
-          INT(x) => parse_map_expr_elem(@syntax.make_int("-" + x))
-          FLOAT(x) => parse_map_expr_elem(@syntax.make_float("-" + x))
-          DOUBLE(x) => parse_map_expr_elem(@syntax.make_double("-" + x))
+          INT(x) => parse_map_expr_elem(@syntax.make_int("-\{x}"))
+          FLOAT(x) => parse_map_expr_elem(@syntax.make_float("-\{x}"))
+          DOUBLE(x) => parse_map_expr_elem(@syntax.make_double("-\{x}"))
           other => {
             let other_loc = state.peek_location()
             state.report_failed_to_parse(

--- a/lexer/lexer.mbt
+++ b/lexer/lexer.mbt
@@ -87,11 +87,11 @@ fn lex_tokens(
   }
 
   fn typed_metavar_payload(name : StringView, kind : StringView) -> String {
-    "$(" + name.to_owned() + ":" + kind.to_owned() + ")"
+    "$(\{name}:\{kind})"
   }
 
   fn inferred_metavar_payload(name : StringView) -> String {
-    "$" + name.to_owned()
+    "$\{name}"
   }
 
   lexmatch input with longest {

--- a/syntax/utils.mbt
+++ b/syntax/utils.mbt
@@ -165,21 +165,21 @@ pub fn make_uminus(loc~ : Location, name : String, arg : Expr) -> Expr {
     ("-", Constant(c=Constant::Int(x), loc=_)) => {
       let new_val = match x {
         ['-', .. num] => num.to_owned()
-        _ => "-" + x
+        _ => "-\{x}"
       }
       make_constant_expr(loc~, Constant::Int(new_val))
     }
     ("-", Constant(c=Constant::Int64(x), loc=_)) => {
       let new_val = match x {
         ['-', .. num] => num.to_owned()
-        _ => "-" + x
+        _ => "-\{x}"
       }
       make_constant_expr(loc~, Constant::Int64(new_val))
     }
     ("-", Constant(c=Constant::Double(x), loc=_)) => {
       let new_val = match x {
         ['-', .. num] => num.to_owned()
-        _ => "-" + x
+        _ => "-\{x}"
       }
       make_constant_expr(loc~, Constant::Double(new_val))
     }
@@ -257,12 +257,12 @@ pub fn desugar_array_augmented_set(
 
   // Generate unique variable names for array and index
   // Use a simple counter instead of random for reproducibility
-  let arr_name = "*array_" + counter.val.to_string()
+  let arr_name = "*array_\{counter.val}"
   counter.val = counter.val + 1
   let arr_loc = loc_of_expression(array)
   let arr_var = Var::{ name: Ident(name=arr_name), loc: arr_loc }
   let arr_ident = make_ident_expr(loc=arr_loc, arr_var)
-  let idx_name = "*index_" + counter.val.to_string()
+  let idx_name = "*index_\{counter.val}"
   counter.val = counter.val + 1
   let idx_loc = loc_of_expression(index)
   let idx_var = Var::{ name: Ident(name=idx_name), loc: idx_loc }


### PR DESCRIPTION
## Summary

Applies the same string-interpolation cleanup started in `lexer/lexer.mbt` across the hand-written source, replacing `+`-based string building with `\{...}` interpolation and dropping the now-unnecessary `.to_owned()` / `.to_string()` conversion calls.

- **lexer/lexer.mbt** — `typed_metavar_payload` / `inferred_metavar_payload` now use `"$(\{name}:\{kind})"` / `"$\{name}"` instead of concatenating `.to_owned()` fragments.
- **handrolled_parser/parser.mbt** — negative numeric literals (`INT`/`FLOAT`/`DOUBLE` in patterns and map keys) built with `"-\{x}"` instead of `"-" + x` (9 sites).
- **syntax/utils.mbt** — unary-minus construction uses `"-\{x}"`; generated array/index variable names use `"*array_\{counter.val}"` / `"*index_\{counter.val}"`, dropping `.to_string()`.

Generated parsers (`yacc_parser`, `mbti_parser`) are intentionally left untouched.

## Test plan

- `moon check` — passes
- `moon test` — 2310 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)